### PR TITLE
Keyword transitioning

### DIFF
--- a/src/main/java/dev/akarah/polaris/script/dsl/DslParser.java
+++ b/src/main/java/dev/akarah/polaris/script/dsl/DslParser.java
@@ -29,7 +29,6 @@ import dev.akarah.polaris.script.expr.ast.func.JvmFunctionAction;
 import dev.akarah.polaris.script.jvm.CodegenUtil;
 import dev.akarah.polaris.script.value.RBoolean;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.entity.animal.Cod;
 
 public class DslParser {
     List<DslToken> tokens;
@@ -292,7 +291,7 @@ public class DslParser {
         if(this.peek() instanceof DslToken.IfKeyword) {
             return parseIf();
         }
-        if(this.peek() instanceof DslToken.ForeachKeyword) {
+        if(this.peek() instanceof DslToken.ForKeyword) {
             return parseForEach();
         }
         if(this.peek() instanceof DslToken.BreakKeyword) {
@@ -341,7 +340,7 @@ public class DslParser {
     }
 
     public ForEachAction parseForEach() {
-        var kw = expect(DslToken.ForeachKeyword.class);
+        var kw = expect(DslToken.ForKeyword.class);
         var variableName = expect(DslToken.Identifier.class);
         expect(DslToken.InKeyword.class);
         var listExpr = parseValue();

--- a/src/main/java/dev/akarah/polaris/script/dsl/DslParser.java
+++ b/src/main/java/dev/akarah/polaris/script/dsl/DslParser.java
@@ -600,8 +600,8 @@ public class DslParser {
             negate = true;
         }
         boolean boolNot = false;
-        if(peek() instanceof DslToken.ExclamationMark) {
-            expect(DslToken.ExclamationMark.class);
+        if(peek() instanceof DslToken.LogicalNot) {
+            expect(DslToken.LogicalNot.class);
             boolNot = true;
         }
         var baseExpr = parseBaseExpression();

--- a/src/main/java/dev/akarah/polaris/script/dsl/DslParser.java
+++ b/src/main/java/dev/akarah/polaris/script/dsl/DslParser.java
@@ -432,11 +432,11 @@ public class DslParser {
     public Expression parseBooleanOperands() {
         var base = parseEqualityExpression();
         while(true) {
-            if(peek() instanceof DslToken.DoubleAmpersand) {
-                expect(DslToken.DoubleAmpersand.class);
+            if(peek() instanceof DslToken.LogicalAnd) {
+                expect(DslToken.LogicalAnd.class);
                 base = new AndExpression(base, parseEqualityExpression());
-            } else if(peek() instanceof DslToken.DoubleLine) {
-                expect(DslToken.DoubleLine.class);
+            } else if(peek() instanceof DslToken.LogicalOr) {
+                expect(DslToken.LogicalOr.class);
                 base = new OrExpression(base, parseEqualityExpression());
             } else {
                 break;

--- a/src/main/java/dev/akarah/polaris/script/dsl/DslToken.java
+++ b/src/main/java/dev/akarah/polaris/script/dsl/DslToken.java
@@ -193,7 +193,7 @@ public interface DslToken {
 
     }
 
-    record ExclamationMark(SpanData span) implements DslToken {
+    record LogicalNot(SpanData span) implements DslToken {
 
     }
 

--- a/src/main/java/dev/akarah/polaris/script/dsl/DslToken.java
+++ b/src/main/java/dev/akarah/polaris/script/dsl/DslToken.java
@@ -114,7 +114,7 @@ public interface DslToken {
 
     }
 
-    record ForeachKeyword(SpanData span) implements DslToken {
+    record ForKeyword(SpanData span) implements DslToken {
 
     }
 

--- a/src/main/java/dev/akarah/polaris/script/dsl/DslToken.java
+++ b/src/main/java/dev/akarah/polaris/script/dsl/DslToken.java
@@ -185,11 +185,11 @@ public interface DslToken {
 
     }
 
-    record DoubleAmpersand(SpanData span) implements DslToken {
+    record LogicalAnd(SpanData span) implements DslToken {
 
     }
 
-    record DoubleLine(SpanData span) implements DslToken {
+    record LogicalOr(SpanData span) implements DslToken {
 
     }
 

--- a/src/main/java/dev/akarah/polaris/script/dsl/DslToken.java
+++ b/src/main/java/dev/akarah/polaris/script/dsl/DslToken.java
@@ -89,8 +89,11 @@ public interface DslToken {
 
     }
 
-
     record IfKeyword(SpanData span) implements DslToken {
+
+    }
+
+    record UnlessKeyword(SpanData span) implements DslToken {
 
     }
 

--- a/src/main/java/dev/akarah/polaris/script/dsl/DslTokenizer.java
+++ b/src/main/java/dev/akarah/polaris/script/dsl/DslTokenizer.java
@@ -108,7 +108,7 @@ public class DslTokenizer {
                         case "local" -> new DslToken.LocalKeyword(this.createSpan(start));
                         case "repeat" -> new DslToken.RepeatKeyword(this.createSpan(start));
                         case "function" -> new DslToken.FunctionKeyword(this.createSpan(start));
-                        case "foreach" -> new DslToken.ForeachKeyword(this.createSpan(start));
+                        case "for" -> new DslToken.ForKeyword(this.createSpan(start));
                         case "in" -> new DslToken.InKeyword(this.createSpan(start));
                         case "break" -> new DslToken.BreakKeyword(this.createSpan(start));
                         case "continue" -> new DslToken.ContinueKeyword(this.createSpan(start));

--- a/src/main/java/dev/akarah/polaris/script/dsl/DslTokenizer.java
+++ b/src/main/java/dev/akarah/polaris/script/dsl/DslTokenizer.java
@@ -114,7 +114,7 @@ public class DslTokenizer {
                         case "or" -> new DslToken.LogicalOr(this.createSpan(start));
                         case "and" -> new DslToken.LogicalAnd(this.createSpan(start));
                         case "not" -> new DslToken.LogicalNot(this.createSpan(start));
-                        case "with", "while", "until" ->
+                        case "with", "while", "until", "is" ->
                                 throw new ParsingException("The keyword '" + string + "' is reserved", this.createSpan(start));
                         case "foreach" ->
                                 throw new ParsingException("The keyword '" + string + "' is deprecated", this.createSpan(start));

--- a/src/main/java/dev/akarah/polaris/script/dsl/DslTokenizer.java
+++ b/src/main/java/dev/akarah/polaris/script/dsl/DslTokenizer.java
@@ -104,6 +104,7 @@ public class DslTokenizer {
                     var string = this.readIdentifier();
                     yield DataResult.success(switch (string) {
                         case "if" -> new DslToken.IfKeyword(this.createSpan(start));
+                        case "unless" -> new DslToken.UnlessKeyword(this.createSpan(start));
                         case "else" -> new DslToken.ElseKeyword(this.createSpan(start));
                         case "local" -> new DslToken.LocalKeyword(this.createSpan(start));
                         case "repeat" -> new DslToken.RepeatKeyword(this.createSpan(start));

--- a/src/main/java/dev/akarah/polaris/script/dsl/DslTokenizer.java
+++ b/src/main/java/dev/akarah/polaris/script/dsl/DslTokenizer.java
@@ -86,16 +86,6 @@ public class DslTokenizer {
                     }
                     yield DataResult.success(new DslToken.MinusSymbol(this.createSpan(start)));
                 }
-                case '|' -> {
-                    this.stringReader.expect('|');
-                    this.stringReader.expect('|');
-                    yield DataResult.success(new DslToken.DoubleLine(this.createSpan(start)));
-                }
-                case '&' -> {
-                    this.stringReader.expect('&');
-                    this.stringReader.expect('&');
-                    yield DataResult.success(new DslToken.DoubleAmpersand(this.createSpan(start)));
-                }
                 case 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
                      'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
                      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N',
@@ -121,6 +111,12 @@ public class DslTokenizer {
                         case "switch" -> new DslToken.SwitchKeyword(this.createSpan(start));
                         case "case" -> new DslToken.CaseKeyword(this.createSpan(start));
                         case "where" -> new DslToken.WhereKeyword(this.createSpan(start));
+                        case "or" -> new DslToken.LogicalOr(this.createSpan(start));
+                        case "and" -> new DslToken.LogicalAnd(this.createSpan(start));
+                        case "with", "while", "until" ->
+                                throw new ParsingException("The keyword '" + string + "' is reserved", this.createSpan(start));
+                        case "foreach" ->
+                                throw new ParsingException("The keyword '" + string + "' is deprecated", this.createSpan(start));
                         default -> new DslToken.Identifier(string, this.createSpan(start));
                     });
                 }


### PR DESCRIPTION
~~turn the language into python~~ 

I think readability is more important than tradition.

- Changes ! to `not`
- Changes || to `or`
- Changes && to `and`
- Changes `foreach` to `for`
- Adds `unless` [inverse of if]
- Reserves `with`, `while`, `is`, and `until`.